### PR TITLE
Almacen de pronts

### DIFF
--- a/pulpo/prompt_store_minio.py
+++ b/pulpo/prompt_store_minio.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Optional
+
+from minio import Minio
+from minio.error import S3Error
+
+from .logueador import log
+
+__all__ = [
+    "MinioPromptStore",
+    "store_llm_prompt",
+    "list_llm_prompts",
+    "get_llm_prompt",
+]
+
+
+class MinioPromptStore:
+    """Almacena y recupera prompts LLM desde MinIO."""
+
+    def __init__(self, *, bucket: Optional[str] = None) -> None:
+        self._bucket = bucket or os.getenv("PROMPTS_MINIO_BUCKET", "llm-prompts")
+        self._client = self._build_client()
+        if self._client:
+            self._ensure_bucket()
+
+    def _build_client(self) -> Optional[Minio]:
+        url = os.getenv("PROMPTS_MINIO_URL")
+        access_key = os.getenv("PROMPTS_MINIO_ACCESS_KEY")
+        secret_key = os.getenv("PROMPTS_MINIO_SECRET_KEY")
+
+        if not url or not access_key or not secret_key:
+            log.debug(
+                "Prompt storage disabled: missing PROMPTS_MINIO_URL/ACCESS_KEY/SECRET_KEY env vars."
+            )
+            return None
+
+        secure = os.getenv("PROMPTS_MINIO_SECURE", "false").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "y",
+            "on",
+        }
+
+        if "://" in url:
+            url = url.split("://", 1)[1]
+
+        try:
+            return Minio(url, access_key=access_key, secret_key=secret_key, secure=secure)
+        except Exception as exc:  # noqa: BLE001
+            log.error(f"Prompt storage disabled: unable to initialise MinIO client ({exc}).")
+            return None
+
+    def _ensure_bucket(self) -> None:
+        if not self._client:
+            return
+        try:
+            if not self._client.bucket_exists(self._bucket):
+                self._client.make_bucket(self._bucket)
+                log.debug("Created MinIO bucket for prompts: %s", self._bucket)
+        except S3Error as exc:
+            log.error("Unable to ensure MinIO bucket '%s': %s", self._bucket, exc)
+            raise
+
+    # ------------------------------------------------------------------ #
+    # Public API
+    # ------------------------------------------------------------------ #
+
+    def store(
+        self,
+        *,
+        agent_name: str,
+        prompt: str,
+        persona_name: Optional[str] = None,
+        persona_id: Optional[str] = None,
+        original_message: Optional[str] = None,
+        prompt_template: Optional[str] = None,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Guarda un prompt en MinIO y devuelve el nombre del objeto."""
+        if not self._client:
+            return None
+
+        timestamp = datetime.now(timezone.utc)
+        payload: Dict[str, Any] = {
+            "timestamp": timestamp.isoformat(),
+            "agent_name": agent_name,
+            "persona_name": persona_name,
+            "persona_id": persona_id,
+            "prompt": prompt,
+            "original_message": original_message,
+            "prompt_template": prompt_template,
+            "model": model,
+            "temperature": temperature,
+        }
+        if metadata:
+            payload["metadata"] = metadata
+
+        job_id = None
+        if metadata and isinstance(metadata, dict):
+            job_id = metadata.get("job_id")
+
+        job_segment = "no-job"
+        if job_id:
+            job_segment = str(job_id).replace("/", "_").strip() or job_segment
+
+        agent_segment = agent_name.replace(" ", "_").lower() or "agent"
+        object_name = (
+            f"{timestamp:%Y/%m/%d}/{job_segment}/{agent_segment}-{timestamp:%H%M%S%f}.json"
+        )
+
+        data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        data_stream = io.BytesIO(data)
+
+        try:
+            self._ensure_bucket()
+            self._client.put_object(
+                self._bucket,
+                object_name,
+                data_stream,
+                len(data),
+                content_type="application/json",
+            )
+            log.debug(
+                "Stored prompt in MinIO: bucket=%s key=%s size=%sB",
+                self._bucket,
+                object_name,
+                len(data),
+            )
+            return object_name
+        except S3Error as exc:
+            log.error("Failed to upload prompt to MinIO: %s", exc)
+        except Exception as exc:  # noqa: BLE001
+            log.error("Unexpected error storing prompt in MinIO: %s", exc)
+        return None
+
+    def list(self, *, prefix: Optional[str] = None, recursive: bool = True) -> Iterable[str]:
+        """Lista los objetos disponibles bajo un prefijo dado."""
+        if not self._client:
+            return []
+        objects = self._client.list_objects(
+            self._bucket, prefix=prefix or "", recursive=recursive
+        )
+        return (obj.object_name for obj in objects)
+
+    def get(self, object_name: str) -> Optional[Dict[str, Any]]:
+        """Recupera el contenido JSON de un objeto almacenado."""
+        if not self._client:
+            return None
+        try:
+            response = self._client.get_object(self._bucket, object_name)
+            try:
+                return json.loads(response.read().decode("utf-8"))
+            finally:
+                response.close()
+                response.release_conn()
+        except S3Error as exc:
+            log.error("Failed to retrieve prompt '%s': %s", object_name, exc)
+        except Exception as exc:  # noqa: BLE001
+            log.error("Unexpected error retrieving prompt '%s': %s", object_name, exc)
+        return None
+
+
+# ---------------------------------------------------------------------- #
+# Helper functions
+# ---------------------------------------------------------------------- #
+
+def _get_store() -> MinioPromptStore:
+    return MinioPromptStore()
+
+
+def store_llm_prompt(**kwargs: Any) -> Optional[str]:
+    """Guarda un prompt LLM usando la configuración global."""
+    return _get_store().store(**kwargs)
+
+
+def list_llm_prompts(prefix: Optional[str] = None, recursive: bool = True) -> Iterable[str]:
+    """Devuelve un iterador con los nombres de objetos almacenados."""
+    return _get_store().list(prefix=prefix, recursive=recursive)
+
+
+def get_llm_prompt(object_name: str) -> Optional[Dict[str, Any]]:
+    """Obtiene un prompt almacenado por su nombre de objeto."""
+    return _get_store().get(object_name)
+

--- a/pulpo/requirements.txt
+++ b/pulpo/requirements.txt
@@ -1,0 +1,18 @@
+aiokafka==0.12.0
+async-timeout==5.0.1
+certifi==2025.1.31
+cffi==1.17.1
+charset-normalizer==3.4.1
+confluent-kafka==2.8.2
+cryptography==44.0.2
+idna==3.10
+packaging==24.2
+#pulpo @ git+http://git@github.com/peperedondorubio/pulpo.git@3610584cc49c338fa8e6c5ecae26536c94d65dd1
+pycparser==2.22
+PyJWT==2.10.1
+requests==2.32.3
+minio>=7.2.0
+setuptools==78.0.2
+typing_extensions==4.12.2
+urllib3==2.3.0
+wheel==0.45.1


### PR DESCRIPTION
Añadido pulpo/prompt_store_minio.py, con MinioPromptStore y helpers store_llm_prompt, list_llm_prompts, get_llm_prompt para persistir/consultar prompts LLM en MinIO usando las env PROMPTS_MINIO_*.

Actualizado requirements.txt para incluir la dependencia minio>=7.2.0 (cliente oficial de MinIO).